### PR TITLE
蔵書を1件削除する処理を追加

### DIFF
--- a/app/Models/Masters/Book.php
+++ b/app/Models/Masters/Book.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Models\Masters;
+
+use App\Models\Model;
+use Illuminate\Support\Collection;
+use Log;
+use Exception;
+
+/**
+ * 蔵書モデル
+ *
+ * @package App\Models\Masters
+ */
+class Book extends Model
+{
+
+    /**
+     * テーブルの物理名
+     *
+     * @var string
+     */
+    protected $table = 'm_books';
+
+    /**
+     * 意図しないデータの更新を防ぎたいカラム群
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'id',
+    ];
+
+    /**
+     * モデルを配列/JSON変換するときに隠蔽されるカラム群
+     *
+     * @var array
+     */
+    protected $hidden = [
+
+    ];
+
+    /**
+     * 主キーを指定して蔵書情報を削除
+     * 
+     * @param int $id 主キー
+     * @return Collection
+     */
+    public function deleteBook(int $id):Collection
+    {
+        $response['status'] = false;
+        try{
+            $target = $this->find($id);
+            $deleted = $target->delete();
+            $response['status'] = $deleted;
+            return collect($response);
+        } catch (Exception $e) {
+            // TODO [v1.0|機能追加] 例外処理の送出方法の決定後に削除時の例外処理の追加すること 
+        }
+    }
+}

--- a/database/factories/BookFactory.php
+++ b/database/factories/BookFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+use Faker\Generator as Faker;
+use App\Models\Masters\Book;
+
+$factory->define(Book::class, function (Faker $faker) {
+    static $number = 1;
+    $result = [
+        'm_book_level_id' => $number,
+        'm_book_genre_id' => $number,
+        'name' => 'テストデータ'.$number,
+        'isbn_code' => '000000000',
+        'published_at' => null,
+        'created_at' => $faker->date,
+        'updated_at' => null,
+        'deleted_at' => null,
+    ];
+    $number++;
+    return $result;
+}, 'デフォルト');

--- a/tests/Unit/Models/Masters/BookTest.php
+++ b/tests/Unit/Models/Masters/BookTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Models\Masters;
+
+use Tests\Unit\Models\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Masters\Book;
+
+/**
+ * 蔵書モデルのテスト
+ *
+ * @package Tests\Unit\Models\Masters
+ */
+class BookTest extends TestCase
+{
+
+    /**
+     * @var Book テスト対象クラス
+     */
+    private $testee;
+
+    /**
+     * 初期処理
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->testee = app()->make(Book::class);
+    }
+
+    /**
+     * @test
+     */
+    public function 任意の主キーを使用してレコードが1件削除されること()
+    {
+        // テストデータを準備
+        $factoryKey = 'デフォルト';
+        $seedingCount = 10;
+        $this->seed(
+            Book::class,
+            $factoryKey,
+            $seedingCount
+        );
+
+        // 検証に使用する主キー
+        $id = 1;
+
+        // 返却値の検証
+        $actual = $this->testee->deleteBook($id);
+        $this->assertTrue($actual->get('status'));
+
+        // DBの実体の検証
+        $actual = $this->testee->find($id);
+        $this->assertEmpty($actual);
+    }
+}


### PR DESCRIPTION
## 概要
- 蔵書モデルのレコードを1件削除する処理を追加
- プロダクトコードの追加に伴うテストコードの追加

## TODO項目
- 機能追加：蔵書削除時の例外処理の追加
